### PR TITLE
Mint Suite/MC: Enable SSE-S3 testing

### DIFF
--- a/functional-tests.sh
+++ b/functional-tests.sh
@@ -289,6 +289,10 @@ function setup()
 {
     start_time=$(get_time)
     assert_success "$start_time" "${FUNCNAME[0]}" mc_cmd mb "${SERVER_ALIAS}/${BUCKET_NAME}"
+    if [ "$ENABLE_SSE_S3TESTS" == "1" ]; then
+            assert_success "$start_time" "SetSSES3Encryption" mc_cmd encrypt set sse-s3 "${SERVER_ALIAS}/${BUCKET_NAME}"
+            log_success "$start_time" "SetSSES3EncryptionWith_mc-cmd"
+    fi
 }
 
 function teardown()


### PR DESCRIPTION
NOTE: To enable SSE-S3 env var the change on mint fork is also necessary!

Since we using SSE-S3 for encryption at rest we have to test it. With this change we're able to set SSE-S3 in the test setup if the env var is set to 1. Then all mc related tests of the mint suite will run against encrypted buckets. Tested it successfully during QA for 1.12.0, but onlx locally. Jenkins run is still to do.

## Description


## Motivation and Context


## How to test this PR?


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fmc%2fpull%2fNNNNN)
